### PR TITLE
fix: корректное поведение подключения Клиентов к Лобби

### DIFF
--- a/src/Tabletop-Engine-Tests/LobbyAcceptanceTest.class.st
+++ b/src/Tabletop-Engine-Tests/LobbyAcceptanceTest.class.st
@@ -52,16 +52,17 @@ LobbyAcceptanceTest >> testSingleUserAndAnEmptyLobby [
 
 { #category : #tests }
 LobbyAcceptanceTest >> testTwoUsersAndALobbyWithFreeTable [
-	| user1 user2 lobby user2UpdatesCount |
+	| user1 user2 lobby |
 	
-	user1 := TEUser new. 
+	user1 := ObservableUser new. 
 	user2 := ObservableUser new.
 	lobby := self lobbyWithFreeTable.
-	lobby subscribeUsers: { user2 }.
-	user2UpdatesCount := user2 updatesCount .
-		
 	lobby subscribeUsers: { user1 }.
+		
+	lobby subscribeUsers: { user2 }.
 	
 	self assert: (user1 tables size) equals: 1.
-	self assert: (user2 updatesCount) equals: user2UpdatesCount .
+	self assert: (user2 tables size) equals: 1.
+	self assert: (user1 updatesCount) equals: 1.
+	self assert: (user2 updatesCount) equals: 1.
 ]

--- a/src/Tabletop-Engine-Tests/ObservableUser.class.st
+++ b/src/Tabletop-Engine-Tests/ObservableUser.class.st
@@ -14,11 +14,13 @@ ObservableUser class >> new [
 
 { #category : #initialization }
 ObservableUser >> initialize [ 
-	updatesCount := 0
+	updatesCount := 0.
+	tables := [ ].
 ]
 
 { #category : #updating }
 ObservableUser >> update: anAspect with: aMeta [
+	super update: anAspect with: aMeta.
 	anAspect = #users ifTrue: [self updatesCount: updatesCount + 1]
 ]
 

--- a/src/Tabletop-Engine/Lobby.class.st
+++ b/src/Tabletop-Engine/Lobby.class.st
@@ -42,7 +42,7 @@ Lobby >> subscribeUsers: anArray [
 	anArray do: 
 		[ :user | 
 			self addDependent: user .
-			user update: #tables with: self ]
+			user update: #users with: self ]
 	
 ]
 


### PR DESCRIPTION
- Лобби рассылает уведомления об обновлении с Аспектом `#users` вместо `#tables`
- Тестовый `ObservableUser` наследует поведение, позволяющее ему получать списки столов